### PR TITLE
Changes to 'IsNavigating' in the NavigationService.

### DIFF
--- a/Mvvm.Nucleus.Maui.Sample/MauiProgram.cs
+++ b/Mvvm.Nucleus.Maui.Sample/MauiProgram.cs
@@ -36,12 +36,13 @@ public static class MauiProgram
 				options.OnAppStart(serviceProvider => Console.WriteLine("OnAppStart"));
 
 				// Some additional configuration is available.
-				options.AddQueryParametersToDictionary = true; // Default: True. If set query parameters (e.a. `route?key=val`) are automatically added to the navigation parameter dictionary.
-				options.AlwaysDisableNavigationAnimation = true; // Default: False. IIf set the `isAnimated` flag while navigating will always be ignored and no animations will be used.
-				options.UseShellNavigationQueryParameters = true; // Default: True. If set navigation parameters are passed to Shell as the one-time-use `ShellNavigationQueryParameters`.
-				options.UseDeconstructPageOnDestroy = true; // Default True. Unload behaviors and unset bindingcontext of pages when they are popped.
-				options.UseDeconstructPopupOnDestroy = true; // Default True. Unset the bindingcontext and parent of popups when they are dismissed
-				options.IgnoreNavigationWhenInProgress = true; // Default: False. If set when trying to navigate using the `INavigationService` while `IsNavigating` is `true` requests will be ignored.
+				options.AddQueryParametersToDictionary = true; // Default `true`. If set, query parameters (e.a. `route?key=val`) are automatically added to the navigation parameter dictionary.
+				options.AlwaysDisableNavigationAnimation = true; // Default `false`. If set, no animations will be used during navigating, regardless of `isAnimated` (only when using the `INavigationService`).
+				options.UseShellNavigationQueryParameters = true; // Default `true`. If set navigation parameters are passed to Shell as the one-time-use.
+				options.UseDeconstructPageOnDestroy = true; // Default `true`. Unload behaviors and unset bindingcontext of pages when they are popped.
+				options.UseDeconstructPopupOnDestroy = true; // Default `true`. Unset the bindingcontext and parent of popups when they are dismissed.
+				options.IgnoreNavigationWhenInProgress = true; // Default `true`. If set, when trying to navigate using the `INavigationService` while it is already busy will ignore other requests.
+				options.IgnoreNavigationWithinMilliseconds = 250; // Default `250`. If set, when trying to navigate using the `INavigationService` while a previous request was done within the given milliseconds will ignore other requests.
 
             })
 			.ConfigureFonts(fonts =>

--- a/Mvvm.Nucleus.Maui.Sample/Mvvm.Nucleus.Maui.Sample.csproj
+++ b/Mvvm.Nucleus.Maui.Sample/Mvvm.Nucleus.Maui.Sample.csproj
@@ -16,7 +16,7 @@
 		<OutputType>Exe</OutputType>
 		<RootNamespace>Mvvm.Nucleus.Maui.Sample</RootNamespace>
 		<UseMaui>true</UseMaui>
-		<MauiVersion>8.0.40</MauiVersion>
+		<MauiVersion>8.0.80</MauiVersion>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/Mvvm.Nucleus.Maui.Sample/ViewModels/NavigationTabViewModel.cs
+++ b/Mvvm.Nucleus.Maui.Sample/ViewModels/NavigationTabViewModel.cs
@@ -21,9 +21,10 @@ public partial class NavigationTabViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private async Task NavigateByRouteAsync()
+    private void NavigateByRoute()
     {
-        await _navigationService.NavigateToRouteAsync(nameof(Details));
+        _ = _navigationService.NavigateToRouteAsync(nameof(Details));
+        _ = _navigationService.NavigateToRouteAsync(nameof(Details));
     }
 
     [RelayCommand]

--- a/Mvvm.Nucleus.Maui.Sample/ViewModels/NavigationTabViewModel.cs
+++ b/Mvvm.Nucleus.Maui.Sample/ViewModels/NavigationTabViewModel.cs
@@ -21,10 +21,9 @@ public partial class NavigationTabViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private void NavigateByRoute()
+    private async Task NavigateByRouteAsync()
     {
-        _ = _navigationService.NavigateToRouteAsync(nameof(Details));
-        _ = _navigationService.NavigateToRouteAsync(nameof(Details));
+        await _navigationService.NavigateToRouteAsync(nameof(Details));
     }
 
     [RelayCommand]
@@ -85,6 +84,13 @@ public partial class NavigationTabViewModel : ObservableObject
                 { "Sample", text }
             });
         });
+    }
+
+    [RelayCommand]
+    private void NavigateMultipleTriggers()
+    {
+        _ = _navigationService.NavigateToRouteAsync(nameof(Details));
+        _ = _navigationService.NavigateToRouteAsync(nameof(Details));
     }
 
     [RelayCommand]

--- a/Mvvm.Nucleus.Maui.Sample/Views/NavigationTab.xaml
+++ b/Mvvm.Nucleus.Maui.Sample/Views/NavigationTab.xaml
@@ -49,6 +49,10 @@
                 Command="{Binding NavigateFromBackgroundThreadCommand}"/>
 
             <Button
+                Text="Navigation ignoring multiple requests"
+                Command="{Binding NavigateMultipleTriggersCommand}"/>
+
+            <Button
                 Text="Switch Tabs"
                 Command="{Binding SwitchTabsCommand}"/>
             

--- a/Mvvm.Nucleus.Maui/Configuration/NucleusMvvmOptions.cs
+++ b/Mvvm.Nucleus.Maui/Configuration/NucleusMvvmOptions.cs
@@ -38,7 +38,12 @@ public class NucleusMvvmOptions
     /// <summary>
     /// Gets or sets a value indicating whether to ignore navigation requests when the <see cref="INavigationService"/> is already navigating.
     /// </summary>
-    public bool IgnoreNavigationWhenInProgress { get; set; } = false;
+    public bool IgnoreNavigationWhenInProgress { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value in milliseconds when navigation requests should be ignored shortly after one has been initiated.
+    /// </summary>
+    public int IgnoreNavigationWithinMilliseconds { get; set; } = 250;
 
     /// <summary>
     /// Gets or sets a value indicating whether to 'destroy' pages after they are no longer in the navigation stack.

--- a/Mvvm.Nucleus.Maui/Models/NucleusNavigationParameters.cs
+++ b/Mvvm.Nucleus.Maui/Models/NucleusNavigationParameters.cs
@@ -14,4 +14,11 @@ public static class NucleusNavigationParameters
     /// Allows to wrap a page in a <see cref="NavigationPage"/> before presenting, which is used for modal presentation.
     /// </summary>
     public const string WrapInNavigationPage = "WrapInNavigationPage";
+
+    /// <summary>
+    /// When set this will make a navigation request always process, even though it would otherwise be ignored
+    /// due to <see cref="NucleusMvvmOptions.IgnoreNavigationWhenInProgress"/> or
+    /// <see cref="NucleusMvvmOptions.IgnoreNavigationWithinMilliseconds"/>.
+    /// </summary>
+    public const string DoNotIgnoreThisNavigationRequest = "DoNotIgnoreThisNavigationRequest";
 }

--- a/Mvvm.Nucleus.Maui/Mvvm.Nucleus.Maui.csproj
+++ b/Mvvm.Nucleus.Maui/Mvvm.Nucleus.Maui.csproj
@@ -17,7 +17,7 @@
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 		<EnableWindowsTargeting>True</EnableWindowsTargeting>
-		<Version>0.2.5</Version>
+		<Version>0.2.6</Version>
 		<PackageId>Mvvm.Nucleus.Maui</PackageId>
 		<Title>Nucleus MVVM for MAUI</Title>
 		<Description>MVVM Framework for MAUI mobile applications. Build on top of MAUI and the MVVM Community Toolkit.</Description>

--- a/Mvvm.Nucleus.Maui/Mvvm.Nucleus.Maui.csproj
+++ b/Mvvm.Nucleus.Maui/Mvvm.Nucleus.Maui.csproj
@@ -17,7 +17,7 @@
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 		<EnableWindowsTargeting>True</EnableWindowsTargeting>
-		<Version>0.2.6</Version>
+		<Version>0.2.6-alpha</Version>
 		<PackageId>Mvvm.Nucleus.Maui</PackageId>
 		<Title>Nucleus MVVM for MAUI</Title>
 		<Description>MVVM Framework for MAUI mobile applications. Build on top of MAUI and the MVVM Community Toolkit.</Description>

--- a/Mvvm.Nucleus.Maui/Mvvm.Nucleus.Maui.csproj
+++ b/Mvvm.Nucleus.Maui/Mvvm.Nucleus.Maui.csproj
@@ -6,7 +6,7 @@
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
 		<UseMaui>true</UseMaui>
-  		<MauiVersion>8.0.40</MauiVersion>
+  		<MauiVersion>8.0.80</MauiVersion>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
@@ -17,7 +17,7 @@
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 		<EnableWindowsTargeting>True</EnableWindowsTargeting>
-		<Version>0.2.6-alpha</Version>
+		<Version>0.3.0</Version>
 		<PackageId>Mvvm.Nucleus.Maui</PackageId>
 		<Title>Nucleus MVVM for MAUI</Title>
 		<Description>MVVM Framework for MAUI mobile applications. Build on top of MAUI and the MVVM Community Toolkit.</Description>
@@ -35,7 +35,7 @@
 
 	<ItemGroup>
 	  <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
-	  <PackageReference Include="CommunityToolkit.Maui" Version="9.0.0" />
+	  <PackageReference Include="CommunityToolkit.Maui" Version="9.0.2" />
 	  <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
   	  <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 	</ItemGroup>

--- a/Mvvm.Nucleus.Maui/Services/Interfaces/INavigationService.cs
+++ b/Mvvm.Nucleus.Maui/Services/Interfaces/INavigationService.cs
@@ -17,6 +17,11 @@ public interface INavigationService
     Uri CurrentRoute { get; }
 
     /// <summary>
+    /// Event that is called whenever <see cref="IsNavigating"/> changes.
+    /// </summary>
+    event EventHandler<bool>? IsNavigatingChanged;
+
+    /// <summary>
     /// Navigates to a given view and corresponding viewmodel.
     /// </summary>
     /// <typeparam name="TView">The <see cref="Type"/> of the view to navigate to.</typeparam>

--- a/Mvvm.Nucleus.Maui/Services/NavigationService.cs
+++ b/Mvvm.Nucleus.Maui/Services/NavigationService.cs
@@ -7,7 +7,9 @@ namespace Mvvm.Nucleus.Maui;
 /// It can be customized through inheritence and registering the service before initializing Nucleus.
 /// </summary>
 public class NavigationService : INavigationService
-{    
+{
+    private static DateTime _isNavigatingLastTriggeredUtc;
+
     private readonly NucleusMvvmOptions _nucleusMvvmOptions;
 
     private readonly ILogger<NavigationService> _logger;
@@ -16,11 +18,17 @@ public class NavigationService : INavigationService
 
     private bool _isNavigating;
 
+    /// <summary>
+    /// Gets the <see cref="object"/> used as a lock to ensure the <see cref="IsNavigating"/> 
+    /// is never set or checked parallel. Only use this if you know what you're doing.
+    /// </summary>
+    protected object IsNavigatingLock { get; }= new object();
+
     /// <inheritdoc/>
     public virtual bool IsNavigating
     { 
         get => _isNavigating;
-        protected set => SetIsNavigating(value);
+        private set => SetIsNavigating(value);
     }
 
     /// <inheritdoc/>
@@ -44,21 +52,21 @@ public class NavigationService : INavigationService
     }
 
     /// <inheritdoc/>
-    public Task NavigateAsync<TView>()
+    public async Task NavigateAsync<TView>()
     {
-        return NavigateAsync<TView>(null);
+        await NavigateAsync<TView>(null);
     }
 
     /// <inheritdoc/>
-    public Task NavigateAsync<TView>(IDictionary<string, object>? navigationParameters, bool isAnimated = true)
+    public async Task NavigateAsync<TView>(IDictionary<string, object>? navigationParameters, bool isAnimated = true)
     {
-        return NavigateAsync(typeof(TView), navigationParameters, isAnimated);
+        await NavigateAsync(typeof(TView), navigationParameters, isAnimated);
     }
 
     /// <inheritdoc/>
     public virtual async Task NavigateAsync(Type viewType, IDictionary<string, object>? navigationParameters = null, bool isAnimated = true)
     {
-        if (ShouldIgnoreNavigationRequest())
+        if (!SetIsNavigatingOrIgnoreRequest())
         {
             return;
         }
@@ -76,11 +84,11 @@ public class NavigationService : INavigationService
     }
 
     /// <inheritdoc/>
-    public virtual Task NavigateToRouteAsync(string route, IDictionary<string, object>? navigationParameters = null, bool isAnimated = true)
+    public virtual async Task NavigateToRouteAsync(string route, IDictionary<string, object>? navigationParameters = null, bool isAnimated = true)
     {
-        if (ShouldIgnoreNavigationRequest())
+        if (!SetIsNavigatingOrIgnoreRequest())
         {
-            return Task.CompletedTask;
+            return;
         }
 
         var parameters = GetOrCreateNavigationParameters(navigationParameters);
@@ -103,38 +111,38 @@ public class NavigationService : INavigationService
 
         NucleusMvvmCore.Current.NavigationParameters = parameters;
 
-        return HandleShellNavigationAsync(() => Shell.Current.GoToAsync(route, GetIsAnimated(isAnimated), GetOrCreateShellNavigationQueryParameters(NucleusMvvmCore.Current.NavigationParameters)));
+        await HandleShellNavigationAsync(() => Shell.Current.GoToAsync(route, GetIsAnimated(isAnimated), GetOrCreateShellNavigationQueryParameters(NucleusMvvmCore.Current.NavigationParameters)));
     }
 
     /// <inheritdoc/>
-    public Task NavigateBackAsync()
+    public async Task NavigateBackAsync()
     {
-        return NavigateBackAsync(null);
+        await NavigateBackAsync(null);
     }
 
     /// <inheritdoc/>
-    public virtual Task NavigateBackAsync(IDictionary<string, object>? navigationParameters, bool isAnimated = true)
+    public virtual async Task NavigateBackAsync(IDictionary<string, object>? navigationParameters, bool isAnimated = true)
     {
-        if (ShouldIgnoreNavigationRequest())
+        if (!SetIsNavigatingOrIgnoreRequest())
         {
-            return Task.CompletedTask;
+            return;
         }
 
         NucleusMvvmCore.Current.NavigationParameters = GetOrCreateNavigationParameters(navigationParameters);
 
-        return HandleShellNavigationAsync(() => Shell.Current.GoToAsync("..", GetIsAnimated(isAnimated), GetOrCreateShellNavigationQueryParameters(NucleusMvvmCore.Current.NavigationParameters)));
+        await HandleShellNavigationAsync(() => Shell.Current.GoToAsync("..", GetIsAnimated(isAnimated), GetOrCreateShellNavigationQueryParameters(NucleusMvvmCore.Current.NavigationParameters)));
     }
 
     /// <inheritdoc/>
-    public Task CloseModalAsync()
+    public async Task CloseModalAsync()
     {
-        return CloseModalAsync(null);
+        await CloseModalAsync(null);
     }
 
     /// <inheritdoc/>
     public virtual async Task CloseModalAsync(IDictionary<string, object>? navigationParameters, bool isAnimated = true)
     {
-        if (ShouldIgnoreNavigationRequest())
+        if (!SetIsNavigatingOrIgnoreRequest())
         {
             return;
         }
@@ -163,15 +171,15 @@ public class NavigationService : INavigationService
     }
 
     /// <inheritdoc/>
-    public Task CloseAllModalAsync()
+    public async Task CloseAllModalAsync()
     {
-        return CloseAllModalAsync(null);
+        await CloseAllModalAsync(null);
     }
 
     /// <inheritdoc/>
     public virtual async Task CloseAllModalAsync(IDictionary<string, object>? navigationParameters, bool isAnimated = true)
     {
-        if (ShouldIgnoreNavigationRequest())
+        if (!SetIsNavigatingOrIgnoreRequest())
         {
             return;
         }
@@ -214,11 +222,6 @@ public class NavigationService : INavigationService
     /// <returns>An awaitable <see cref="Task"/>.</returns>
     protected virtual async Task HandleShellNavigationAsync (Func<Task> shellNavigationTask)
     {
-        if (ShouldIgnoreNavigationRequest())
-        {
-            return;
-        }
-
         IsNavigating = true;
 
         try
@@ -272,6 +275,90 @@ public class NavigationService : INavigationService
                 nucleusMvvmPageBehavior.DestroyAfterNavigatedFrom = true;
             }
         }
+    }
+
+    /// <summary>
+    /// Set the value of <see cref="IsNavigating"/>. This will trigger <see cref="IsNavigatingChanged"/>.
+    /// Generally you should not set this value manually. In Nucleus this value is set and checked within a lock
+    /// using the <see cref="IsNavigatingLock"/> object, to ensure this never happens in parallel.
+    /// to ensure
+    /// </summary>
+    /// <param name="value"></param>
+    protected void SetIsNavigating(bool value)
+    {
+        if (_isNavigating == value)
+        {
+            return;
+        }
+        
+        _isNavigating = value;
+
+        if (_isNavigating)
+        {
+            _isNavigatingLastTriggeredUtc = DateTime.UtcNow;
+        }
+        
+        IsNavigatingChanged?.Invoke(this, value);
+        
+        if (_nucleusMvvmOptions.IgnoreNavigationWhenInProgress)
+        {
+            _logger?.LogInformation($"IsNavigating changed to '{_isNavigating}'." + (_isNavigating ? " Incoming navigation requests will be ignored." : string.Empty));
+        }
+    }
+
+    /// <summary>
+    /// This function checks if a navigation request should be processed, which depends on the configuration values
+    /// <see cref="NucleusMvvmOptions.IgnoreNavigationWhenInProgress"/> and <see cref="NucleusMvvmOptions.IgnoreNavigationWithinMilliseconds"/>.
+    /// Even when these values are configured, they can be bypassed by passing ''
+    /// </summary>
+    /// <returns>A value indicating whether or not to ignore a navigation request.</returns>
+    protected virtual bool SetIsNavigatingOrIgnoreRequest(IDictionary<string, object>? navigationParameters = null)
+    {
+        if ((!_nucleusMvvmOptions.IgnoreNavigationWhenInProgress && _nucleusMvvmOptions.IgnoreNavigationWithinMilliseconds <= 0) ||
+            navigationParameters?.ContainsKey(NucleusNavigationParameters.DoNotIgnoreThisNavigationRequest) == true &&
+            navigationParameters[NucleusNavigationParameters.DoNotIgnoreThisNavigationRequest] is bool value && value)
+        {
+            IsNavigating = true;
+            return true;
+        }
+
+        var isNavigationAllowed = false;
+        var isNavigationTooSoon = false;
+
+        var isNavigatingLastTriggeredUtc = _isNavigatingLastTriggeredUtc;
+        
+        lock (IsNavigatingLock)
+        {
+            if (!IsNavigating)
+            {
+                IsNavigating = true;
+                isNavigationAllowed = true;
+                
+                _isNavigatingLastTriggeredUtc = DateTime.UtcNow;
+            }
+
+            if (!_nucleusMvvmOptions.IgnoreNavigationWhenInProgress)
+            {
+                isNavigationAllowed = true;
+            }
+        }
+
+        if (_nucleusMvvmOptions.IgnoreNavigationWithinMilliseconds >= 0 && isNavigatingLastTriggeredUtc != default && isNavigationAllowed)
+        {
+            isNavigationTooSoon = (DateTime.UtcNow - isNavigatingLastTriggeredUtc).TotalMilliseconds < _nucleusMvvmOptions.IgnoreNavigationWithinMilliseconds;
+            isNavigationAllowed = !isNavigationTooSoon;
+        }
+
+        if (!isNavigationAllowed)
+        {
+            var detailsMessage = isNavigationTooSoon ?
+                $"Ignoring this navigation request as it is within {_nucleusMvvmOptions.IgnoreNavigationWithinMilliseconds}ms since the previous one. You can change this value in {nameof(NucleusMvvmOptions)}.{nameof(NucleusMvvmOptions.IgnoreNavigationWithinMilliseconds)}." :
+                $"Ignoring this navigation request as another request is already in progress. You can change this value in {nameof(NucleusMvvmOptions)}.{nameof(NucleusMvvmOptions.IgnoreNavigationWhenInProgress)}.";
+
+            _logger?.LogWarning(detailsMessage);
+        }
+
+        return isNavigationAllowed;
     }
 
     private async void ShellNavigating(object sender, ShellNavigatingEventArgs e)
@@ -402,11 +489,6 @@ public class NavigationService : INavigationService
         return result;
     }
 
-    private bool GetIsAnimated(bool isAnimated)
-    {
-        return _nucleusMvvmOptions.AlwaysDisableNavigationAnimation ? false : isAnimated;
-    }
-
     private IList<Page> GetTransientPagesFromNavigationStack()
     {
         var result = new List<Page>(NucleusMvvmCore.Current.Shell?.CurrentPage?.Navigation?.NavigationStack?.Skip(1) ?? new List<Page>());
@@ -433,32 +515,8 @@ public class NavigationService : INavigationService
         return result;
     }
 
-    private bool ShouldIgnoreNavigationRequest()
+    private bool GetIsAnimated(bool isAnimated)
     {
-        if (_nucleusMvvmOptions.IgnoreNavigationWhenInProgress && IsNavigating)
-        {
-            _logger.LogWarning($"Ignoring this navigation request as we're already navigating. You can change this setting in the MauiProgram initialization.");
-
-            return true;
-        }
-
-        return false;
-    }
-
-    private void SetIsNavigating(bool value)
-    {
-        if (_isNavigating == value)
-        {
-            return;
-        }
-        
-        _isNavigating = value;
-        
-        IsNavigatingChanged?.Invoke(this, value);
-        
-        if (_nucleusMvvmOptions.IgnoreNavigationWhenInProgress)
-        {
-            _logger?.LogInformation($"IsNavigating changed to '{_isNavigating}'." + (_isNavigating ? " Incoming navigation requests will be ignored." : string.Empty));
-        }
+        return _nucleusMvvmOptions.AlwaysDisableNavigationAnimation ? false : isAnimated;
     }
 }

--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ An optional `NucleusViewModel` is included to have some boilerplate events like 
 
 Within the options the following additional settings can be changed:
 
-- `AddQueryParametersToDictionary`: Default `true`. If set query parameters (e.a. `route?key=val`) are automatically added to the navigation parameter dictionary.
-- `AlwaysDisableNavigationAnimation`: Default `false`. If set no animations will be used during navigating, regardless of `isAnimated` (only when using the `INavigationService`).
-- `IgnoreNavigationWhenInProgress`: Default `false`. If set when trying to navigate using the `INavigationService` while it is already busy requests will be ignored.
-- `UseShellNavigationQueryParameters`: Default `true`. If set navigation parameters are passed to Shell as the one-time-use `ShellNavigationQueryParameters`.
+- `AddQueryParametersToDictionary`: Default `true`. If set, query parameters (e.a. `route?key=val`) are automatically added to the navigation parameter dictionary.
+- `AlwaysDisableNavigationAnimation`: Default `false`. If set, no animations will be used during navigating, regardless of `isAnimated` (only when using the `INavigationService`).
+- `IgnoreNavigationWhenInProgress`: Default `true`. If set, when trying to navigate using the `INavigationService` while it is already busy will ignore other requests.
+- `IgnoreNavigationWithinMilliseconds`: Default `250`. If set, when trying to navigate using the `INavigationService` while a previous request was done within the given milliseconds will ignore other requests.
+- `UseShellNavigationQueryParameters`: Default `true`. If set navigation parameters are passed to Shell as the one-time-use.`ShellNavigationQueryParameters`.
 - `UseDeconstructPageOnDestroy`: Default `true`. Unload behaviors and unset bindingcontext of pages when they are popped.
 - `UseDeconstructPopupOnDestroy`: Default `true`. Unset the bindingcontext and parent of popups when they are dismissed.
 
@@ -77,7 +78,7 @@ Values can be retrieved using regular `IDictionary` methods, but additionally th
 - `NavigationParameters.GetValueOrDefault<T>(key, defaultValue)`
 - `NavigationParameters.GetStructOrDefault<T>(key, defaultValue)`
 
-If using Shell these parameters can also be used as described in the [MAUI documentation](https://learn.microsoft.com/en-us/dotnet/maui/fundamentals/shell/navigation#pass-data), including accessing them through `IQueryAttributable` and `QueryProperty`. By default the values will be wrapped inside `ShellNavigationQueryParameters`, but this can be turned off in the Nucleus MVVM options (see [Getting started](#getting-started)).
+These parameters can also be used as described in the [MAUI documentation](https://learn.microsoft.com/en-us/dotnet/maui/fundamentals/shell/navigation#pass-data), including accessing them through `IQueryAttributable` and `QueryProperty`. By default the values will be wrapped inside `ShellNavigationQueryParameters`, but this can be turned off in the Nucleus MVVM options (see [Getting started](#getting-started)).
 
 ### Modal navigation
 
@@ -86,7 +87,16 @@ When navigating Nucleus will look for certain parameters in the navigation param
 - `NucleusNavigationParameters.NavigatingPresentationMode`: Expects a [PresentationMode](https://learn.microsoft.com/en-us/dotnet/api/microsoft.maui.controls.presentationmode?) that will be added to the page.
 - `NucleusNavigationParameters.WrapInNavigationPage`: Wraps a NavigationPage around the target, allowing for deeper navigation within a modal page.
 
-Note that above parameters allow for modal presentation in Shell including deeper navigation (see the Sample Project in the repository). However this appears an underdeveloped area of Shell and might not be stable. See 
+Note that above parameters allow for modal presentation in Shell including deeper navigation (see the Sample Project in the repository). However this appears an underdeveloped area of Shell and might not be stable.
+
+### Avoiding double navigation
+
+On slower devices it is a common issue that users are able to trigger multiple navigation requests by pressing a button one more than once,
+either too quickly or while waiting for the navigation to start. When using the CommunityToolkit `(Async)RelayCommand` this problem is reduced, as the Command will be disabled while it's processing. But since a navigation Task returns before it has finished navigating, it can still occur.
+
+Nucleus offers two features to improve the navigation behavior, both are enabled by default. These are `IgnoreNavigationWhenInProgress` and `IgnoreNavigationWithinMilliseconds`, see [Configuration].
+
+In specific cases you might want to bypass these restrictions, but not disable them fully. In those cases you can add `NucleusNavigationParameters.DoNotIgnoreThisNavigationRequest` in the NavigationParameters and set it to true.
 
 ### Navigation interfaces
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Nucleus offers two features to improve the navigation behavior, both are enabled
 
 In specific cases you might want to bypass these restrictions, but not disable them fully. In those cases you can add `NucleusNavigationParameters.DoNotIgnoreThisNavigationRequest` in the NavigationParameters and set it to true.
 
+Note that due to the nature of the `PopupService` there is no logic for avoiding multiple triggers, as it always expects a return object.
+
 ### Navigation interfaces
 
 - `IApplicationLifeCycleAware`: When the app is going to the background or returning.


### PR DESCRIPTION
These changes ensure that 'IsNavigating' is set correctly and early, so the feature 'IgnoreNavigationWhenInProgress' works as expected for preventing double navigation events. Additionally an event has been added to subscribe to changes in this value.

Completes #1 