### PR TITLE
Replaced Application.Current.MainPage with the IoC variant.

### DIFF
--- a/Mvvm.Nucleus.Maui/AppBuilderExtensions.cs
+++ b/Mvvm.Nucleus.Maui/AppBuilderExtensions.cs
@@ -33,6 +33,7 @@ public static class AppBuilderExtensions
 
         builder.Services.TryAddSingleton<Application, TApp>();
         builder.Services.TryAddTransient<Shell, TShell>();
+        builder.Services.TryAddSingleton<IWindowCreator, NucleusWindowCreator>();
         builder.Services.AddSingleton<NucleusMvvmCore>();
         builder.Services.TryAddSingleton<IViewFactory, ViewFactory>();
         builder.Services.TryAddSingleton<INavigationService, NavigationService>();
@@ -42,15 +43,8 @@ public static class AppBuilderExtensions
         builder.Services.AddSingleton<IApplication>(serviceProvider =>
         {
             var nucleusMvvmCore = serviceProvider.GetRequiredService<NucleusMvvmCore>();
-            nucleusMvvmCore.Initialize(serviceProvider);
 
-            var nucleusMvvmOptions = serviceProvider.GetRequiredService<NucleusMvvmOptions>();
-            nucleusMvvmOptions.OnInitialized?.Invoke(serviceProvider);
-
-            var shell = serviceProvider.GetRequiredService<Shell>();
             var application = nucleusMvvmCore.Application;
-
-            application.MainPage = shell;
             application.PageAppearing += OnApplicationAppearing;
 
             return application;

--- a/Mvvm.Nucleus.Maui/Mvvm.Nucleus.Maui.csproj
+++ b/Mvvm.Nucleus.Maui/Mvvm.Nucleus.Maui.csproj
@@ -17,7 +17,7 @@
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 		<EnableWindowsTargeting>True</EnableWindowsTargeting>
-		<Version>0.3.0</Version>
+		<Version>0.3.1</Version>
 		<PackageId>Mvvm.Nucleus.Maui</PackageId>
 		<Title>Nucleus MVVM for MAUI</Title>
 		<Description>MVVM Framework for MAUI mobile applications. Build on top of MAUI and the MVVM Community Toolkit.</Description>
@@ -34,8 +34,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
-	  <PackageReference Include="CommunityToolkit.Maui" Version="9.0.2" />
+	  <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.0" />
+	  <PackageReference Include="CommunityToolkit.Maui" Version="9.0.3" />
 	  <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
   	  <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 	</ItemGroup>

--- a/Mvvm.Nucleus.Maui/NucleusMvvmCore.cs
+++ b/Mvvm.Nucleus.Maui/NucleusMvvmCore.cs
@@ -17,6 +17,8 @@ public class NucleusMvvmCore
 
     internal NucleusMvvmOptions NucleusMvvmOptions { get; }
 
+    internal static bool IsInitialized => _current != null;
+
     internal IDictionary<string, object> NavigationParameters
     {
         get => _navigationParameters;
@@ -70,8 +72,8 @@ public class NucleusMvvmCore
     /// </summary>
     public Shell? Shell
     {
-        get => _shell ?? throw new InvalidOperationException("NucleusMvvm could not detect a Shell. Set the MainPage to a Shell before using any Shell-related function, such as navigating.");
-        private set => RegisterShell(value);
+        get => _shell ?? throw new InvalidOperationException("NucleusMvvm could not detect a Shell.");
+        internal set => RegisterShell(value);
     }
 
     /// <summary>
@@ -80,13 +82,18 @@ public class NucleusMvvmCore
     public Window? Window
     {
         get => _window ?? throw new InvalidOperationException("NucleusMvvm could not detect a Window.");
-        private set => RegisterWindow(value);
+        internal set => RegisterWindow(value);
     }
+
+    /// <summary>
+    /// Gets the current 'MainPage' from the <see cref="Window"/>. This is a read-only alternative to the deprecated 'Application.Current.MainPage'.
+    /// </summary>
+    public Page MainPage => _window?.Page ?? throw new InvalidOperationException("NucleusMvvm could not detect a MainPage.");
 
     /// <summary>
     /// Gets the current <see cref="Page"/>. It takes into account modally presented pages, as well as pages like <see cref="FlyoutPage"/>.
     /// </summary>
-    public Page CurrentPage => GetCurrentPage(Application.Current?.MainPage ?? throw new InvalidOperationException("NucleusMvvm could not detect the current page."));
+    public Page CurrentPage => GetCurrentPage(MainPage ?? throw new InvalidOperationException("NucleusMvvm could not detect the current page."));
 
     /// <summary>
     /// Initializes a new instance of the <see cref="NucleusMvvmCore"/> class.
@@ -106,17 +113,7 @@ public class NucleusMvvmCore
     internal void Initialize(IServiceProvider serviceProvider)
     {
         Current = this;
-
         ServiceProvider = serviceProvider;
-
-        Application.PropertyChanged += (sender, e) =>
-        {
-            if (e.PropertyName == nameof(Application.MainPage))
-            {
-                Shell = (sender as Application)?.MainPage as Shell;
-                Window = (sender as Application)?.MainPage?.Window;
-            }
-        };
     }
 
     internal async void RunTaskInVoidAndTrackException(Func<Task> task, Action? onFinished = null, [CallerMemberName] string callerName = "")

--- a/Mvvm.Nucleus.Maui/Services/NucleusWindowCreator.cs
+++ b/Mvvm.Nucleus.Maui/Services/NucleusWindowCreator.cs
@@ -1,0 +1,41 @@
+namespace Mvvm.Nucleus.Maui;
+
+/// <summary>
+/// <see cref="NucleusWindowCreator"/> creates a <see cref="Window"/> that sets <see cref="Shell"/>
+/// as a MainPage. Register your own <see cref="IWindowCreator"/> or child of this class for any
+/// custom <see cref="Window"/> logic.
+/// </summary>
+public class NucleusWindowCreator : IWindowCreator
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IWindowCreator"/> class.
+    /// </summary>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/>.</param>
+    public NucleusWindowCreator(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+    
+    /// <inheritdoc/>
+    public virtual Window CreateWindow(Application app, IActivationState? activationState)
+    {
+        if (!NucleusMvvmCore.IsInitialized)
+        {
+            var nucleusMvvmCore = _serviceProvider.GetRequiredService<NucleusMvvmCore>();
+            var nucleusMvvmOptions = _serviceProvider.GetRequiredService<NucleusMvvmOptions>();
+
+            nucleusMvvmCore.Initialize(_serviceProvider);
+            nucleusMvvmOptions.OnInitialized?.Invoke(_serviceProvider);
+        }
+
+        var shell = _serviceProvider.GetRequiredService<Shell>();
+        var window = new Window(shell);
+
+        NucleusMvvmCore.Current.Shell = shell;
+        NucleusMvvmCore.Current.Window = window;
+
+        return window;
+    }
+}


### PR DESCRIPTION
The **Application.Current.MainPage** is marked for deprecation and will be removed in future MAUI releases. This PR replaces this with the introduced **IWindowCreator**.

In this implementation it will create a Window when requested and sets the **Shell** from the Nucleus initializer as the Page.

It is possible to override / subclass this service in advanced scenarios. For Windows, or other possibly configurations where multiple windows are possible, this could use further improvements.

See:
- https://github.com/dotnet/docs-maui/pull/1819
- https://learn.microsoft.com/en-us/dotnet/maui/whats-new/dotnet-9?view=net-maui-8.0#mainpage